### PR TITLE
Restoring node property methods to its original logic, but handles both bool and string case

### DIFF
--- a/lib/jenkins_api_client/node.rb
+++ b/lib/jenkins_api_client/node.rb
@@ -255,7 +255,8 @@ module JenkinsApi
         define_method("is_#{meth_suffix}?") do |node_name|
           @logger.info "Obtaining '#{meth_suffix}' property of '#{node_name}'"
           response_json = @client.api_get_request("/computer")
-          response_json["computer"][index(node_name)]["#{meth_suffix}"]
+          resp = response_json["computer"][index(node_name)]["#{meth_suffix}"].to_s
+          resp =~ /False/i ? false : true
         end
       end
 

--- a/spec/unit_tests/node_spec.rb
+++ b/spec/unit_tests/node_spec.rb
@@ -24,6 +24,18 @@ describe JenkinsApi::Client::Node do
           "offline"     => false,
         ]
       }
+      @offline_slave_in_string        = {
+        "computer" => [
+          "displayName" => "slave",
+          "offline"     => "true",
+        ]
+      }
+      @online_slave_in_string        = {
+        "computer" => [
+          "displayName" => "slave",
+          "offline"     => "false",
+        ]
+      }
       computer_sample_xml_filename = '../fixtures/files/computer_sample.xml'
       @sample_computer_xml = File.read(
         File.expand_path(computer_sample_xml_filename , __FILE__)
@@ -187,6 +199,24 @@ describe JenkinsApi::Client::Node do
             :api_get_request
           ).twice.and_return(
             @online_slave
+          )
+          @node.method("is_offline?").call("slave").should be_false
+        end
+
+        it "returns false if the node is online and have a string value on its attr" do
+          @client.should_receive(
+            :api_get_request
+          ).twice.and_return(
+            @offline_slave_in_string
+          )
+          @node.method("is_offline?").call("slave").should be_true
+        end
+
+        it "returns false if the node is online and have a string value on its attr" do
+          @client.should_receive(
+            :api_get_request
+          ).twice.and_return(
+            @online_slave_in_string
           )
           @node.method("is_offline?").call("slave").should be_false
         end


### PR DESCRIPTION
Hope this can be merged and close https://github.com/arangamani/jenkins_api_client/issues/164